### PR TITLE
Use APIv3 logout endpoint before local session cleanup

### DIFF
--- a/app/AppContext.tsx
+++ b/app/AppContext.tsx
@@ -72,13 +72,20 @@ const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
 
 
   const clearBeforeLogout = async () => {
-    const keys = await AsyncStorage.getAllKeys();
-    await Promise.all(keys.map((key) => deleteFromStorage(key)));
+    let keys: readonly string[] = [];
+
+    try {
+      keys = await AsyncStorage.getAllKeys();
+    } catch (error) {
+      console.error("Error reading storage keys during logout", error);
+    }
+
+    await Promise.allSettled(keys.map((key) => deleteFromStorage(key)));
     setUserInfo(null);
     setToken(undefined);
     setIsTokenChecked(false);
     useAuthStore.getState().logout();
-    queryClient.removeQueries();
+    queryClient.clear();
   };
 
   const deleteFromStorage = async (key: string): Promise<void> => {

--- a/app/components/home/profile/MainProfileInfo.tsx
+++ b/app/components/home/profile/MainProfileInfo.tsx
@@ -13,6 +13,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   getGetApiGetUsersRankingQueryKey,
   getApiDeleteAccount,
+  usePostApiLogout,
   usePostApiChangeVisibilityInRanking,
 } from "../../../../api/generated/user/user";
 
@@ -41,20 +42,27 @@ const MainProfileInfo: React.FC<MainProfileInfoProps> = ({
 
   const { mutateAsync: changeVisibilityMutation, isPending: isChangingVisibility } =
     usePostApiChangeVisibilityInRanking();
+  const { mutateAsync: logoutMutation } = usePostApiLogout();
 
   useEffect(() => {
     setIsVisibleInRankingState(isVisibleInRanking);
   }, [isVisibleInRanking]);
 
   const logout = async (): Promise<void> => {
-    await clearBeforeLogout();
-    router.push("/");
+    try {
+      await logoutMutation();
+    } catch (error) {
+      console.error("Logout API request failed, proceeding with local logout", error);
+    } finally {
+      await clearBeforeLogout();
+      router.push("/");
+    }
   };
 
   const deleteAccount = async (): Promise<void> => {
     await getApiDeleteAccount();
     setIsDeleteConfirmationDialogVisible(false);
-    logout();
+    await logout();
   };
 
   const changeVisibility = async (newValue: boolean): Promise<void> => {


### PR DESCRIPTION
## Summary
- call `POST /api/logout` during logout in `MainProfileInfo` using generated `usePostApiLogout` mutation
- keep logout resilient: when API request fails, local cleanup still runs in `finally` and navigation returns to root
- preserve and harden local cleanup in `AppContext.clearBeforeLogout` (AsyncStorage cleanup, Zustand logout, query cache clear)

## Details
- `app/components/home/profile/MainProfileInfo.tsx`
  - added `usePostApiLogout`
  - `logout()` now: try server logout -> always local cleanup + `router.push("/")`
  - delete account flow now `await logout()` after successful account deletion
- `app/AppContext.tsx`
  - made storage cleanup resilient with guarded `getAllKeys` + `Promise.allSettled`
  - query cache cleanup uses `queryClient.clear()`

## Verification
- `npm exec tsc --noEmit`