### PR TITLE
Task 49 profile and ranking APIv3 compatibility

### DIFF
--- a/app/components/home/exercises/Exercises.tsx
+++ b/app/components/home/exercises/Exercises.tsx
@@ -25,7 +25,7 @@ import {
 import { EnumLookupDto, ExerciseResponseDto } from "../../../../api/generated/model";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../../../../stores/useAuthStore";
-import { hasPermissionClaim } from "../../../../utils/authorization";
+import { isAdminUser } from "../../../../utils/authorization";
 
 interface ExercisesProps {
   isCreatePlanDayMode?: boolean;
@@ -90,7 +90,7 @@ const Exercises: React.FC<ExercisesProps> = ({
   }, [userExercisesData]);
 
 
-  const isAdmin = hasPermissionClaim(user, "admin.access");
+  const isAdmin = isAdminUser(user);
 
   const filteredGlobalExercisesByBodyPart = useMemo(() => {
     return selectedBodyPart

--- a/app/components/home/profile/MainProfileInfo.tsx
+++ b/app/components/home/profile/MainProfileInfo.tsx
@@ -10,6 +10,7 @@ import Checkbox from "../../elements/Checkbox";
 import { useTranslation } from "react-i18next";
 import LanguageSwitcher from "../../elements/LanguageSwitcher";
 import { useQueryClient } from "@tanstack/react-query";
+import { useAuthStore } from "../../../../stores/useAuthStore";
 import {
   getGetApiGetUsersRankingQueryKey,
   getApiDeleteAccount,
@@ -31,6 +32,7 @@ const MainProfileInfo: React.FC<MainProfileInfoProps> = ({
     clearBeforeLogout,
     changeIsVisibleInRanking,
   } = useAppContext();
+  const { user, setUser } = useAuthStore();
   const [
     isDeleteConfirmationDialogVisible,
     setIsDeleteConfirmationDialogVisible,
@@ -62,13 +64,22 @@ const MainProfileInfo: React.FC<MainProfileInfoProps> = ({
   const deleteAccount = async (): Promise<void> => {
     await getApiDeleteAccount();
     setIsDeleteConfirmationDialogVisible(false);
-    await logout();
+    await clearBeforeLogout();
+    router.push("/");
   };
 
   const changeVisibility = async (newValue: boolean): Promise<void> => {
     const previousValue = isVisibleInRankingState;
+    const previousUser = user;
+
     setIsVisibleInRankingState(newValue);
     changeIsVisibleInRanking(newValue);
+    if (user) {
+      setUser({
+        ...user,
+        isVisibleInRanking: newValue,
+      });
+    }
 
     try {
       await changeVisibilityMutation({
@@ -85,6 +96,7 @@ const MainProfileInfo: React.FC<MainProfileInfoProps> = ({
     } catch {
       setIsVisibleInRankingState(previousValue);
       changeIsVisibleInRanking(previousValue);
+      setUser(previousUser);
     }
   };
 

--- a/enums/Roles.ts
+++ b/enums/Roles.ts
@@ -1,0 +1,6 @@
+export enum Roles {
+  User = "User",
+  Admin = "Admin",
+  Tester = "Tester",
+  Trainer = "Trainer",
+}

--- a/utils/authorization.ts
+++ b/utils/authorization.ts
@@ -1,4 +1,5 @@
 import type { UserInfoDto } from "../api/generated/model";
+import { Roles } from "../enums/Roles";
 
 const normalize = (value: string): string => value.trim().toLowerCase();
 
@@ -24,5 +25,5 @@ export const hasPermissionClaim = (
 };
 
 export const isAdminUser = (user: UserInfoDto | null | undefined): boolean => {
-  return hasPermissionClaim(user, "admin.access");
+  return hasRole(user, Roles.Admin) || hasPermissionClaim(user, "admin.access");
 };


### PR DESCRIPTION
## Summary
- align profile/ranking authorization to APIv3 model by centralizing admin detection with role support and permission-claim fallback
- add `Roles` enum (`User`, `Admin`, `Tester`, `Trainer`) and wire authorization checks to backend role naming
- fix profile account deletion flow to skip logout API after delete and clear local session directly

## Verification
- `lsp_diagnostics` clean for updated files
- `npx tsc --noEmit`
- `npx expo export --platform web`

Closes #49