### PR TITLE
Task 52 auth and session flow alignment with APIv3

### DIFF
--- a/app/AppContext.tsx
+++ b/app/AppContext.tsx
@@ -83,7 +83,7 @@ const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     await Promise.allSettled(keys.map((key) => deleteFromStorage(key)));
     setUserInfo(null);
     setToken(undefined);
-    setIsTokenChecked(false);
+    setIsTokenChecked(true);
     useAuthStore.getState().logout();
     queryClient.clear();
   };

--- a/app/Login.tsx
+++ b/app/Login.tsx
@@ -42,12 +42,13 @@ const Login: React.FC = () => {
   useFocusEffect(
     useCallback(() => {
       setErrors([]);
-      setAppErrors([]);
     }, [])
   );
 
   const login = async (): Promise<void> => {
-    if (!username || !password) {
+    const normalizedUsername = username?.trim();
+
+    if (!normalizedUsername || !password) {
       setErrors([t('auth.usernameAndPasswordRequired')]);
       return;
     }
@@ -55,7 +56,7 @@ const Login: React.FC = () => {
     mutate(
       {
         data: {
-          name: username,
+          name: normalizedUsername,
           password: password,
         },
       },
@@ -91,10 +92,13 @@ const Login: React.FC = () => {
             setToken(loginResponse.token);
             setUser(userInfo);
             setUserInfo(userInfo);
+            setAppErrors([]);
             router.push("/Home");
           } catch (error) {
             console.error("Error storing credentials:", error);
-            setErrors([t('auth.failedToStoreCredentials')]);
+            const message = t('auth.failedToStoreCredentials');
+            setErrors([message]);
+            setAppErrors([message]);
           }
         },
         onError: (error: any) => {

--- a/hooks/useAppInitialization.ts
+++ b/hooks/useAppInitialization.ts
@@ -13,11 +13,13 @@ import { usePostApiAppConfigGetAppVersion, postApiAppConfigGetAppVersionResponse
 import { getApiCheckToken } from "../api/generated/user/user";
 import { UserInfoDto } from "../api/generated/model";
 
+const SESSION_KEYS_TO_CLEAR = ["token", "username", "id", "email", "userInfo", "gym"] as const;
+
 export const useAppInitialization = () => {
   const router = useRouter();
   const [appConfig, setAppConfig] = useState<AppConfigInfoDto | null>(null);
   const [canValidateToken, setCanValidateToken] = useState<boolean>(false);
-  const { setIsTokenChecked, isTokenChecked, setUserInfo, setToken, token } = useAppContext();
+  const { setErrors, setIsTokenChecked, isTokenChecked, setUserInfo, setToken, token } = useAppContext();
   
   const { mutate: checkVersion } = usePostApiAppConfigGetAppVersion({});
 
@@ -55,6 +57,7 @@ export const useAppInitialization = () => {
     const tokenToValidate = token ?? (await AsyncStorage.getItem("token"));
 
     if (!tokenToValidate) {
+      useAuthStore.getState().logout();
       setIsTokenChecked(true);
       return;
     }
@@ -68,22 +71,13 @@ export const useAppInitialization = () => {
       const response = await getApiCheckToken();
       if (response?.data && "name" in response.data) {
         const userInfo = response.data as UserInfoDto;
-        await setSession(userInfo);
+        await setSession(userInfo, tokenToValidate);
         return;
       }
-      setToken(undefined);
-      setUserInfo(null);
-      useAuthStore.getState().setUser(null);
-      useAuthStore.getState().setToken(null);
-      setIsTokenChecked(true);
+      await resetSessionState("Authentication failed. Please log in again.");
     } catch (error) {
       console.error("Token check failed:", error);
-      await AsyncStorage.multiRemove(["token", "userInfo", "gym"]);
-      setToken(undefined);
-      setUserInfo(null);
-      useAuthStore.getState().setUser(null);
-      useAuthStore.getState().setToken(null);
-      setIsTokenChecked(true);
+      await resetSessionState("Session expired. Please log in again.");
     }
   };
 
@@ -100,16 +94,32 @@ export const useAppInitialization = () => {
     }
   };
 
-  const setSession = async (userInfo: UserInfoDto): Promise<void> => {
+  const setSession = async (userInfo: UserInfoDto, sessionToken: string): Promise<void> => {
     await AsyncStorage.setItem("username", userInfo.name ?? "");
     await AsyncStorage.setItem("id", userInfo._id ?? "");
     if (userInfo.email) {
       await AsyncStorage.setItem("email", userInfo.email);
     }
+    setErrors([]);
+    setToken(sessionToken);
+    useAuthStore.getState().setToken(sessionToken);
     setIsTokenChecked(true);
     setUserInfo(userInfo);
     useAuthStore.getState().setUser(userInfo);
     router.replace("/Home");
+  };
+
+  const resetSessionState = async (errorMessage?: string): Promise<void> => {
+    await AsyncStorage.multiRemove([...SESSION_KEYS_TO_CLEAR]);
+    setToken(undefined);
+    setUserInfo(null);
+    useAuthStore.getState().logout();
+    setIsTokenChecked(true);
+
+    if (errorMessage) {
+      setErrors([errorMessage]);
+      router.replace("/Login");
+    }
   };
 
   const getAppVersion = () => {


### PR DESCRIPTION
## Summary
- align login payload/response handling with APIv3 by normalizing username input and surfacing auth storage errors consistently in UI state
- harden app startup session bootstrap by synchronizing token/user store state on successful `checkToken` and fully clearing stale session data on token failure
- keep logout/session state consistent by setting `isTokenChecked` after local cleanup and routing auth failures back to login with visible error context

## Verification
- `lsp_diagnostics` clean for updated files
- `npx tsc --noEmit`
- `npx expo export --platform web`

Closes #52