### PR TITLE
Task 48 plan switch sync and plan-day layout fixes

### DIFF
--- a/app/components/elements/BackgroundMainSection.tsx
+++ b/app/components/elements/BackgroundMainSection.tsx
@@ -6,7 +6,7 @@ interface BackgroundMainSectionProps {
 }
 
 const BackgroundMainSection: React.FC<BackgroundMainSectionProps> = ({ children }) => {
-  return <View className="relative flex flex-1 bg-bgColor">{children}</View>;
+  return <View className="relative flex flex-1 w-full bg-bgColor">{children}</View>;
 };
 
 

--- a/app/components/home/plan/TrainingPlan.tsx
+++ b/app/components/home/plan/TrainingPlan.tsx
@@ -28,14 +28,18 @@ import {
   usePostApiIdSetNewActivePlan,
   usePostApiIdDeletePlan,
   getGetApiIdGetPlansListQueryKey,
+  getGetApiIdCheckIsUserHavePlanQueryKey,
 } from "../../../../api/generated/plan/plan";
 import {
   useGetApiPlanDayIdGetPlanDaysInfo,
   useGetApiPlanDayIdDeletePlanDay,
+  getGetApiPlanDayIdGetPlanDaysInfoQueryKey,
+  getGetApiPlanDayIdGetPlanDaysTypesQueryKey,
 } from "../../../../api/generated/plan-day/plan-day";
 import { useAppContext } from "../../../AppContext";
 import { useQueryClient } from "@tanstack/react-query";
 import { getGetApiIdGetPlanConfigQueryKey } from "../../../../api/generated/plan/plan";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import Toast from "react-native-toast-message";
 import { toastConfig } from "../../../../helpers/toastConfig";
@@ -101,9 +105,13 @@ const TrainingPlan: React.FC = () => {
 
   const refetchAll = async () => {
     await queryClient.invalidateQueries({ queryKey: getGetApiIdGetPlanConfigQueryKey(userId) });
+    await queryClient.invalidateQueries({ queryKey: getGetApiIdGetPlansListQueryKey(userId) });
+    await queryClient.invalidateQueries({ queryKey: getGetApiIdCheckIsUserHavePlanQueryKey(userId) });
+    await queryClient.invalidateQueries({ queryKey: getGetApiPlanDayIdGetPlanDaysTypesQueryKey(userId) });
     if (planConfig?._id) {
-        // We rely on React Query dependency to fetch plan days, but we can invalidate to be sure
-        // The key for plan days depends on planConfig._id
+      await queryClient.invalidateQueries({
+        queryKey: getGetApiPlanDayIdGetPlanDaysInfoQueryKey(planConfig._id),
+      });
     }
   };
 
@@ -223,8 +231,12 @@ const TrainingPlan: React.FC = () => {
     try {
         if(newPlanConfig._id){
             setIsSwitchingPlan(true);
-            await setNewActivePlanMutation({ id: userId, data: { _id: newPlanConfig._id } as any });
+            await setNewActivePlanMutation({ id: userId, data: { _id: newPlanConfig._id } });
             await queryClient.invalidateQueries({ queryKey: getGetApiIdGetPlanConfigQueryKey(userId) });
+            await queryClient.invalidateQueries({ queryKey: getGetApiIdGetPlansListQueryKey(userId) });
+            await queryClient.invalidateQueries({ queryKey: getGetApiIdCheckIsUserHavePlanQueryKey(userId) });
+            await queryClient.invalidateQueries({ queryKey: getGetApiPlanDayIdGetPlanDaysTypesQueryKey(userId) });
+            await AsyncStorage.multiRemove(["planDay", "trainingSessionScores"]);
         }
     } catch (e: unknown) {
       console.error(e);
@@ -262,11 +274,28 @@ const TrainingPlan: React.FC = () => {
         {isLoading ? (
           <ViewLoading />
         ) : !planConfig ? (
-          <View className="flex flex-row w-full justify-center items-center h-full">
+          <View className="flex flex-col w-full justify-center items-center h-full px-5" style={{ gap: 16 }}>
+            <View className="w-full" style={{ gap: 4 }}>
+              <Text
+                className="text-base smallPhone:text-sm text-fifthColor"
+                style={{
+                  fontFamily: "OpenSans_400Regular",
+                }}
+              >
+                {t("plans.emptyPlanSubtitle")}
+              </Text>
+            </View>
             <CustomButton
               onPress={() => togglePlanConfigPopUp(true)}
               text={t('plans.createPlanCta')}
               buttonStyleType={ButtonStyle.success}
+              width="w-full"
+            />
+            <CustomButton
+              onPress={showCopyPlanDialog}
+              text={t('plans.copyPlan')}
+              buttonStyleType={ButtonStyle.default}
+              width="w-full"
             />
           </View>
         ) : (

--- a/app/components/home/plan/planDay/CreatePlanDay.tsx
+++ b/app/components/home/plan/planDay/CreatePlanDay.tsx
@@ -147,13 +147,17 @@ const CreatePlanDay: React.FC<CreatePlanDayProps> = (props) => {
   ) => {
     const exercises = mapExercisesListToSend(exercisesArg);
     if (props.planId) {
+      const planId = props.planId;
       createPlanDayMutation(
         {
-          id: props.planId,
+          id: planId,
           data: { name: planNameArg, exercises: exercises },
         },
         {
           onSuccess: () => {
+            queryClient.invalidateQueries({
+              queryKey: getGetApiPlanDayIdGetPlanDaysInfoQueryKey(planId),
+            });
             closeForm();
           },
         }
@@ -180,9 +184,11 @@ const CreatePlanDay: React.FC<CreatePlanDayProps> = (props) => {
             queryClient.invalidateQueries({
               queryKey: getGetApiPlanDayIdGetPlanDayQueryKey(props.planDayId!),
             });
-            queryClient.invalidateQueries({
-              queryKey: getGetApiPlanDayIdGetPlanDaysInfoQueryKey(props.planDayId!),
-            });
+            if (props.planId) {
+              queryClient.invalidateQueries({
+                queryKey: getGetApiPlanDayIdGetPlanDaysInfoQueryKey(props.planId),
+              });
+            }
             closeForm();
           },
         }

--- a/app/components/home/plan/planDay/CreatePlanDayContext.tsx
+++ b/app/components/home/plan/planDay/CreatePlanDayContext.tsx
@@ -37,12 +37,12 @@ const PlanDayProvider: React.FC<PlanDayProviderProps> = ({
   const [currentStep, setCurrentStep] = useState<number>(-2);
 
   const goToNext = useCallback(() => {
-    setCurrentStep(currentStep + 1);
-  }, [currentStep]);
+    setCurrentStep((prevCurrentStep) => prevCurrentStep + 1);
+  }, []);
 
   const goBack = useCallback(() => {
-    setCurrentStep(currentStep - 1);
-  }, [currentStep]);
+    setCurrentStep((prevCurrentStep) => prevCurrentStep - 1);
+  }, []);
 
   return (
     <PlanDayContext.Provider

--- a/app/components/home/plan/planDay/exerciseList/ExerciseList.tsx
+++ b/app/components/home/plan/planDay/exerciseList/ExerciseList.tsx
@@ -20,7 +20,7 @@ const ExerciseList: React.FC<ExerciseListProps> = (props) => {
 
   return (
     <View className="flex flex-col flex-1 " style={{ gap: 8 }}>
-      <View className="flex flex-row justify-between">
+      <View className="flex flex-row justify-between w-full">
         <Text
           style={{ fontFamily: "OpenSans_700Bold" }}
           className="text-textColor text-base smallPhone:text-sm"

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -63,6 +63,8 @@
     "createPlan": "Create new",
     "back": "Back",
     "createPlanCta": "Create plan",
+    "emptyPlanTitle": "You don't have a plan yet",
+    "emptyPlanSubtitle": "Create a new plan or copy an existing one with a code.",
     "currentTrainingPlan": "Current training plan:",
     "addTrainingDay": "Add training day",
     "deleteConfirmTitle": "Delete: {{name}}",

--- a/app/locales/pl.json
+++ b/app/locales/pl.json
@@ -63,6 +63,8 @@
     "createPlan": "Utwórz nowy",
     "back": "Wróć",
     "createPlanCta": "Utwórz plan",
+    "emptyPlanTitle": "Nie masz jeszcze planu",
+    "emptyPlanSubtitle": "Utwórz nowy plan albo skopiuj istniejący kodem.",
     "currentTrainingPlan": "Aktualny plan treningowy:",
     "addTrainingDay": "Dodaj dzień treningowy",
     "deleteConfirmTitle": "Usuń: {{name}}",


### PR DESCRIPTION
## Summary
- fix plan-day data refresh and query invalidation paths in the plan configuration flow, including active plan switching and plan-day CRUD sync
- clear stale training session local state after active plan change so training start no longer resumes an outdated plan-day
- improve plan empty-state UX (create/copy messaging) and fix full-width layout in plan-day exercise selection modal

## Verification
- `lsp_diagnostics` clean on updated files
- `npx tsc --noEmit`
- `npx expo export --platform web`

Closes #48